### PR TITLE
User id switching

### DIFF
--- a/src/main/java/uk/org/llgc/annotation/store/adapters/AbstractStoreAdapter.java
+++ b/src/main/java/uk/org/llgc/annotation/store/adapters/AbstractStoreAdapter.java
@@ -211,9 +211,11 @@ public abstract class AbstractStoreAdapter implements StoreAdapter {
         if (tSavedUser == null) {
             // first try changing from https to http
             try {
+                String tOriginalId = pUser.getId();
                 pUser.setId(pUser.getId().replaceAll("https://","http://"));
                 tSavedUser = this.getUser(pUser);
                 if (tSavedUser == null) {
+                    pUser.setId(tOriginalId);
                     return this.saveUser(pUser);
                 } else {
                     return tSavedUser;

--- a/src/main/java/uk/org/llgc/annotation/store/adapters/StoreAdapter.java
+++ b/src/main/java/uk/org/llgc/annotation/store/adapters/StoreAdapter.java
@@ -47,9 +47,16 @@ public interface StoreAdapter {
 	public AnnotationList getAnnotationsFromPage(final User pUser, final Canvas pPage) throws IOException;
 
     // CRUD users
+    /**
+     * This will save the user if it doesnt exist
+     */
     public User retrieveUser(final User pUser) throws IOException;
+    /**
+     * This will get the user using the ID
+     */
     public User getUser(final User pUser) throws IOException;
     public User saveUser(final User pUser) throws IOException;
+    public User deleteUser(final User pUser) throws IOException;
     public List<User> getUsers() throws IOException;
     public List<User> getUsers(final String pGroup) throws IOException;
 

--- a/src/main/java/uk/org/llgc/annotation/store/adapters/elastic/ElasticStore.java
+++ b/src/main/java/uk/org/llgc/annotation/store/adapters/elastic/ElasticStore.java
@@ -713,6 +713,15 @@ public class ElasticStore extends AbstractStoreAdapter implements StoreAdapter {
         return pUser;
     }
 
+    public User deleteUser(final User pUser) throws IOException {
+        DeleteRequest tDelete = new DeleteRequest(_index);
+        tDelete.id(pUser.getId());
+
+        tDelete.setRefreshPolicy(_policy);
+        _client.delete(tDelete, RequestOptions.DEFAULT);
+        return pUser;
+    }
+
     protected User json2user(final Map<String,Object> tUserJson) throws IOException {
         User tSavedUser = new User();
         if (tUserJson.get("authenticationMethod").equals(LocalUser.AUTH_METHOD)) {

--- a/src/main/java/uk/org/llgc/annotation/store/adapters/rdf/AbstractRDFStore.java
+++ b/src/main/java/uk/org/llgc/annotation/store/adapters/rdf/AbstractRDFStore.java
@@ -639,6 +639,11 @@ public abstract class AbstractRDFStore extends AbstractStoreAdapter {
         return pUser;
     }
 
+    public User deleteUser(final User pUser) throws IOException {
+        this.deleteAnnotation(pUser.getId());
+        return pUser;
+    }
+
     public Collection createCollection(final Collection pCollection) throws IOException {
         while (true) {
             if (this.getNamedModel(pCollection.getId()) != null){

--- a/src/main/java/uk/org/llgc/annotation/store/adapters/solr/SolrStore.java
+++ b/src/main/java/uk/org/llgc/annotation/store/adapters/solr/SolrStore.java
@@ -546,6 +546,19 @@ public class SolrStore extends AbstractStoreAdapter implements StoreAdapter {
         return pUser;
     }
 
+    public User deleteUser(final User pUser) throws IOException {
+        List<String> tOldIds = new ArrayList<String>();
+		tOldIds.add(pUser.getId());
+		try {
+			_solrClient.deleteById(tOldIds);
+			_solrClient.commit();
+		} catch(SolrServerException tException) {
+			tException.printStackTrace();
+			throw new IOException("Failed to remove user due to " + tException);
+		}
+        return pUser;
+    }
+
     protected User json2user(final SolrDocument pDoc) throws IOException {
         User tUser = new User();
         if (pDoc.get("authenticationMethod").equals(LocalUser.AUTH_METHOD)) {

--- a/src/main/java/uk/org/llgc/annotation/store/controllers/AuthorisationController.java
+++ b/src/main/java/uk/org/llgc/annotation/store/controllers/AuthorisationController.java
@@ -126,4 +126,8 @@ public class AuthorisationController {
         }
         return false;
     }
+
+    public boolean deleteUser(final User pAdmin, final User pTarget) {
+        return pAdmin.isAdmin();
+    }
 }

--- a/src/main/java/uk/org/llgc/annotation/store/servlets/UserServlet.java
+++ b/src/main/java/uk/org/llgc/annotation/store/servlets/UserServlet.java
@@ -37,6 +37,29 @@ public class UserServlet extends HttpServlet {
 	public void doGet(final HttpServletRequest pReq, final HttpServletResponse pRes) throws IOException {
     }
 
+	public void doDelete(final HttpServletRequest pReq, final HttpServletResponse pRes) throws IOException {
+        AuthorisationController tAuth = new AuthorisationController(pReq);
+        User tLoggedInUser = new UserService(pReq).getUser();
+
+        User tUser = new User();
+        try {
+            tUser.setId(pReq.getParameter("uri"));
+        } catch (URISyntaxException tExcpt) {
+            _logger.debug("failed to delete " + tLoggedInUser + "due to: " + tLoggedInUser);
+        }
+
+        Map<String,Object> tResponse = new HashMap<String,Object>();
+        if (tAuth.deleteUser(tLoggedInUser, tUser)) {
+            _store.deleteUser(tUser);
+            tResponse.put("code", pRes.SC_OK);
+            tResponse.put("message", "User deleted");
+            this.sendJson(pRes, pRes.SC_OK, tResponse);
+        } else {
+            tResponse.put("code", pRes.SC_UNAUTHORIZED);
+            tResponse.put("message", "You can only delete users if you are Admin");
+            this.sendJson(pRes, pRes.SC_UNAUTHORIZED, tResponse);
+        }
+    }
 
 	public void doPost(final HttpServletRequest pReq, final HttpServletResponse pRes) throws IOException {
         AuthorisationController tAuth = new AuthorisationController(pReq);

--- a/src/main/webapp/admin/user-collections.xhtml
+++ b/src/main/webapp/admin/user-collections.xhtml
@@ -31,6 +31,8 @@
                         <li><b>Created</b>: <h:outputText value="#{collUser.created}"/></li>
                         <li><b>Modified</b>: <h:outputText value="#{collUser.lastModified}"/></li>
                     </ul>
+
+                    <a href="users.xhtml" class="btn btn-danger mb-2" data-mode="delete_user" data-label="#{collUser.name}" data-url="#{collUser.id}" onclick="showConfirm(event); return false;"><i class="fas secondary"></i> Delete User</a>
                     <hr/>
                     <script src="/js/collection.js"></script>
                     <h2>Collections</h2>
@@ -95,6 +97,8 @@
                         link.href = url + link.href;
                     }
                 </script>
+
+                <ui:include src="/WEB-INF/templates/dialogues/confirm.xhtml"/>
             </main>
         </ui:define>
     </ui:composition>

--- a/src/main/webapp/js/collection.js
+++ b/src/main/webapp/js/collection.js
@@ -370,7 +370,15 @@ function showConfirm(event) {
         id.dataset.collection = dataEl.dataset.collection;
 
         confirmButton.onclick = deleteAnnotation;
+    } else if (mode === 'delete_user') {
+        header.innerHTML = 'Delete User';
+        text.innerHTML = 'Are you sure you want to remove "' + dataEl.dataset.label + '"?';
+        text.innerHTML += '<br/><br/>';
+        text.innerHTML += "<b>Note:</b> this will not delete any of the user's data and the user will be recreated if they login again. This delete will mostly be of use when developing the Annotation server to delete test users.";
 
+        id.value = dataEl.dataset.url;
+
+        confirmButton.onclick = deleteUser;
     }
 
     $('#confirm').modal('toggle');
@@ -384,7 +392,7 @@ function deleteAnnotations() {
         method:'DELETE',
         }).then(res => {
             if (res.ok) {
-                setLoading("confirmButton", "Confirm")
+                clearLoading("confirmButton", "Delete");
                 window.location.href = 'manifest.xhtml?collection=' + canvas_id.dataset.collection + "&iiif-content=" + canvas_id.dataset.manifest
             } else {
                 throw new Error('Failed to delete annotations: ' + res.status + " " + res.statusText);
@@ -400,8 +408,24 @@ function deleteAnnotation() {
         method:'DELETE',
         }).then(res => {
             if (res.ok) {
-                setLoading("confirmButton", "Confirm");
+                clearLoading("confirmButton", "Delete");
                 window.location.href = 'annotations.xhtml?collection=' + data.dataset.collection + "&manifest=" + data.dataset.manifest + "&iiif-content=" + data.dataset.canvas;
+            } else {
+                throw new Error('Failed to delete annotation: ' + res.status + " " + res.statusText);
+            }
+        });
+}
+
+function deleteUser() {
+    let data = document.getElementById("confirmId");
+    setLoading("confirmButton", "Deleting");
+
+    fetch('/user/delete?uri=' + data.value, {
+        method:'DELETE',
+        }).then(res => {
+            if (res.ok) {
+                clearLoading("confirmButton", "Delete");
+                window.location.href = '/admin/users.xhtml';
             } else {
                 throw new Error('Failed to delete annotation: ' + res.status + " " + res.statusText);
             }

--- a/src/test/java/uk/org/llgc/annotation/store/test/TestUsers.java
+++ b/src/test/java/uk/org/llgc/annotation/store/test/TestUsers.java
@@ -477,4 +477,55 @@ public class TestUsers extends TestUtils {
         }
         assertTrue("I didn't find all of the expected users in: " + tLocalUsers, tFoundUser1 && tFoundUser2);
     }
+
+    /**
+     * This is useful if you have switch the baseURI from http to https and need 
+     * to retain the users
+     */ 
+    @Test 
+    public void testBaseURISwitch() throws IOException, URISyntaxException {
+        User tUser1 = new User();
+        tUser1.setId("http://example.com/user1");
+        tUser1.setShortId("user1");
+        tUser1.setName("name1");
+        tUser1.setEmail("name1@glen.com");
+        tUser1.setAdmin(true);
+        tUser1.setPicture("http://picture.net");
+        _store.saveUser(tUser1);
+
+        User tHttpsUser = new User();
+        tHttpsUser.setId("https://example.com/user1");
+            
+        User tFoundUser = _store.retrieveUser(tHttpsUser);
+
+        assertNotNull("Couldn't retrieve user using the https url", tFoundUser);
+        assertEquals("Unexpected id, expected to find http id", tUser1.getId(), tFoundUser.getId());
+
+        assertTrue("Expected to find an admin user", tFoundUser.isAdmin());
+    }
+
+     @Test 
+    public void testDeleteUser() throws IOException, URISyntaxException {
+        User tUser1 = new User();
+        tUser1.setId("http://example.com/user1");
+        tUser1.setShortId("user1");
+        tUser1.setName("name1");
+        tUser1.setEmail("name1@glen.com");
+        tUser1.setAdmin(true);
+        tUser1.setPicture("http://picture.net");
+        _store.saveUser(tUser1);
+
+        User tSearchUser = new User();
+        tSearchUser.setId(tUser1.getId());
+        User tFoundUser = _store.retrieveUser(tSearchUser);
+
+        assertNotNull("Couldn't retrieve user before deleting it", tFoundUser);
+
+        _store.deleteUser(tSearchUser);
+
+        tFoundUser = _store.getUser(tSearchUser);
+
+        assertNull("Found user but expected it to be deleted.", tFoundUser);
+    }
+
 }

--- a/src/test/java/uk/org/llgc/annotation/store/test/TestUsers.java
+++ b/src/test/java/uk/org/llgc/annotation/store/test/TestUsers.java
@@ -504,6 +504,21 @@ public class TestUsers extends TestUtils {
         assertTrue("Expected to find an admin user", tFoundUser.isAdmin());
     }
 
+    @Test 
+    public void testHttpsURL() throws IOException, URISyntaxException {
+        User tUser1 = new User();
+        tUser1.setId("https://example.com/user1");
+        tUser1.setShortId("user1");
+        tUser1.setName("name1");
+        tUser1.setEmail("name1@glen.com");
+        tUser1.setAdmin(true);
+        tUser1.setPicture("http://picture.net");
+        User tFoundUser = _store.retrieveUser(tUser1);
+
+        assertEquals("Expected https URL", "https://example.com/user1", tFoundUser.getId());
+    }
+
+
      @Test 
     public void testDeleteUser() throws IOException, URISyntaxException {
         User tUser1 = new User();


### PR DESCRIPTION
I've done two things,  I've added a delete user function (in the user details page) and also matched a https login with a http user id. 

So to hopefully sort the issue if you delete the https user you created while we were testing then the other users should be OK when they login as it will rely on the https/http id matching. 